### PR TITLE
Fix codedeploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is done by:
 ## Usage
 ```hcl
 module "lambda_api" {
-  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v0.1.0"
+  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v0.2.0"
   app_name                      = "my-lambda"
   env                           = "dev"
   codedeploy_service_role_arn   = module.acs.power_builder_role.arn

--- a/examples/no-codedeploy/example.tf
+++ b/examples/no-codedeploy/example.tf
@@ -9,7 +9,7 @@ module "acs" {
 
 module "lambda_api" {
   # source                        = "../../"
-  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v0.1.0"
+  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v0.2.0"
   app_name                      = "my-lambda"
   env                           = "dev"
   lambda_zip_file               = "./src/lambda.zip"

--- a/examples/simple-lambda-with-deploy-test/example.tf
+++ b/examples/simple-lambda-with-deploy-test/example.tf
@@ -9,7 +9,7 @@ module "acs" {
 
 module "lambda_api" {
   # source                        = "../../"
-  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v0.1.0"
+  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v0.2.0"
   app_name                      = "my-lambda-codedeploy"
   env                           = "dev"
   codedeploy_service_role_arn   = module.acs.power_builder_role.arn

--- a/main.tf
+++ b/main.tf
@@ -263,15 +263,15 @@ resource "aws_lambda_function" "api_lambda" {
 }
 
 resource "aws_lambda_alias" "live" {
-  count = !var.use_codedeploy ? 1 : 0
-  name          = "live"
-  description   = "ALB sends traffic to this version"
-  function_name = aws_lambda_function.api_lambda.arn
+  count            = ! var.use_codedeploy ? 1 : 0
+  name             = "live"
+  description      = "ALB sends traffic to this version"
+  function_name    = aws_lambda_function.api_lambda.arn
   function_version = aws_lambda_function.api_lambda.version
 }
 
 resource "aws_lambda_alias" "live_codedeploy" {
-  count = var.use_codedeploy ? 1 : 0
+  count         = var.use_codedeploy ? 1 : 0
   name          = "live"
   description   = "ALB sends traffic to this version"
   function_name = aws_lambda_function.api_lambda.arn
@@ -288,13 +288,13 @@ resource "aws_lambda_alias" "live_codedeploy" {
 # ==================== CodeDeploy ====================
 
 resource "aws_codedeploy_app" "app" {
-  count = var.use_codedeploy ? 1 : 0
+  count            = var.use_codedeploy ? 1 : 0
   compute_platform = "Lambda"
   name             = "${local.long_name}-cd"
 }
 
 resource "aws_codedeploy_deployment_group" "deployment_group" {
-  count = var.use_codedeploy ? 1 : 0
+  count                  = var.use_codedeploy ? 1 : 0
   app_name               = aws_codedeploy_app.app[0].name
   deployment_group_name  = "${local.long_name}-dg"
   service_role_arn       = var.codedeploy_service_role_arn
@@ -326,7 +326,7 @@ resource "aws_iam_role_policy_attachment" "lambda_cloudwatch_attach" {
 # ==================== AppSpec file ====================
 
 resource "local_file" "appspec_json" {
-  count = var.use_codedeploy ? 1 : 0
+  count    = var.use_codedeploy ? 1 : 0
   filename = "${path.cwd}/appspec.json"
   content = jsonencode({
     version = 1
@@ -334,10 +334,10 @@ resource "local_file" "appspec_json" {
       apiLambdaFunction = {
         Type = "AWS::Lambda::Function"
         Properties = {
-          Name  = aws_lambda_function.api_lambda.function_name
-          Alias = aws_lambda_alias.live_codedeploy[0].name
+          Name           = aws_lambda_function.api_lambda.function_name
+          Alias          = aws_lambda_alias.live_codedeploy[0].name
           CurrentVersion = aws_lambda_alias.live_codedeploy[0].function_version
-          TargetVersion = aws_lambda_function.api_lambda.version
+          TargetVersion  = aws_lambda_function.api_lambda.version
         }
       }
     }],

--- a/main.tf
+++ b/main.tf
@@ -332,7 +332,7 @@ resource "local_file" "appspec_json" {
         Properties = {
           Name  = aws_lambda_function.api_lambda.function_name
           Alias = aws_lambda_alias.live_codedeploy[0].name
-          CurrentVersion = aws_lambda_function.api_lambda.version # TODO: figure out how to get previous version for rollback
+          CurrentVersion = aws_lambda_alias.live_codedeploy.function_version
           TargetVersion = aws_lambda_function.api_lambda.version
         }
       }

--- a/main.tf
+++ b/main.tf
@@ -332,7 +332,7 @@ resource "local_file" "appspec_json" {
         Properties = {
           Name  = aws_lambda_function.api_lambda.function_name
           Alias = aws_lambda_alias.live_codedeploy[0].name
-          CurrentVersion = aws_lambda_alias.live_codedeploy.function_version
+          CurrentVersion = aws_lambda_alias.live_codedeploy[0].function_version
           TargetVersion = aws_lambda_function.api_lambda.version
         }
       }

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@ output "codedeploy_deployment_group" {
 }
 
 output "codedeploy_appspec_json_file" {
-  value = var.use_codedeploy ? local_file.appspec_json[0].filename : null
+  value = var.use_codedeploy ? local_file.appspec_json.*.filename : null
 }
 
 output "alb" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,15 +7,15 @@ output "lambda_security_group" {
 }
 
 output "lambda_live_alias" {
-  value = var.use_codedeploy ? aws_lambda_alias.live_codedeploy[0] : aws_lambda_alias.live[0]
+  value = length(aws_lambda_alias.live_codedeploy) > 0 ? aws_lambda_alias.live_codedeploy[0] : aws_lambda_alias.live[0]
 }
 
 output "codedeploy_deployment_group" {
-  value = var.use_codedeploy ? aws_codedeploy_deployment_group.deployment_group[0] : null
+  value = length(aws_codedeploy_deployment_group.deployment_group) > 0 ? aws_codedeploy_deployment_group.deployment_group[0] : null
 }
 
 output "codedeploy_appspec_json_file" {
-  value = var.use_codedeploy ? local_file.appspec_json.*.filename : null
+  value = length(local_file.appspec_json) > 0 ? local_file.appspec_json[0].filename : null
 }
 
 output "alb" {


### PR DESCRIPTION
Fix the outputs.
Don't create test resources if you aren't using CodeDeploy. Because if you aren't using CodeDeploy, `terraform apply` updates the alias immediately, so there's no use for the test resources.