### PR TITLE
fix: app_name max length to 28

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: '/' # Check files in .github/workflows
+    schedule:
+      interval: monthly
+    target-branch: main
+
+  - package-ecosystem: terraform
+    directory: '/'
+    schedule:
+      interval: monthly
+    target-branch: main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,15 +2,15 @@ name: CI
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   env:
     name: Set Env Vars
     runs-on: ubuntu-latest
     steps:
-      - name: Set up DEV Environment Variables
-        if: github.base_ref == 'master'
+      - name: Set up Environment Variables
+        if: github.base_ref == 'main'
         run: |
           matrix='{
             "env":[
@@ -62,7 +62,7 @@ jobs:
       matrix: ${{ fromJson(needs.env.outputs.matrix) }}
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Also Note: CodePipeline and CodeDeploy cannot be used together to deploy a Lambd
 For a Zip file lambda
 ```hcl
 module "lambda_api" {
-  source       = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.0.0"
+  source       = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.0.1"
   app_name     = "my-lambda-codedeploy-dev"
   env          = "dev"
   zip_filename = "./src/lambda.zip"
@@ -51,7 +51,7 @@ module "lambda_api" {
 For a docker image lambda:
 ```hcl
 module "lambda_api" {
-  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.0.0"
+  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.0.1"
   app_name                      = "my-docker-lambda"
   image_uri                     = "my-image-from-my-ecr:latest"
   hosted_zone                   = module.acs.route53_zone
@@ -92,7 +92,7 @@ module "lambda_api" {
 ## Inputs
 | Name | Type  | Description | Default |
 | --- | --- | --- | --- |
-| app_name | string | Application name to name your Lambda API and other resources (Must be <= 24 alphanumeric characters) | |
+| app_name | string | Application name to name your Lambda API and other resources (Must be <= 28 alphanumeric characters) | |
 | image_uri | string | ECR Image URI containing the function's deployment package (conflicts with `zip_file`)| null |
 | zip_filename | string | File that contains your compiled or zipped source code. |
 | zip_handler | string | Lambda event handler |
@@ -231,4 +231,4 @@ If manual rollback is needed after the deployment has completed, that can be don
 
 If you require additional variables please create an [issue](https://github.com/byu-oit/terraform-aws-lambda-api/issues)
  and/or a [pull request](https://github.com/byu-oit/terraform-aws-lambda-api/pulls) to add the variable and reach 
- out to the Terraform Working Group on slack (`#terraform` channel).
+ out to the Application Engineering SpecOps Green team (`IT Collaboration` -> `OIT ENG AppEng - SpecOps Green` channel).

--- a/changelog.md
+++ b/changelog.md
@@ -10,3 +10,7 @@
 - removed `use_codedeploy` variable - just include the codedeploy variables to enable codedeploy
 - removed `env` variable - just include the env inside the `app_name` variable 
 - added `domain_url` variable to enable a custom API URL
+
+## v2.0.1
+3/11/2022 - increased `app_name` variable length
+- increased `app_name` variable length from 24 to 28

--- a/examples/docker-lambda/docker.tf
+++ b/examples/docker-lambda/docker.tf
@@ -9,7 +9,7 @@ module "acs" {
 
 module "lambda_api" {
   #  source                        = "../../"
-  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.0.0"
+  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.0.1"
   app_name                      = "my-docker-lambda"
   image_uri                     = "my-image-from-my-ecr:latest"
   hosted_zone                   = module.acs.route53_zone

--- a/examples/no-codedeploy/example.tf
+++ b/examples/no-codedeploy/example.tf
@@ -9,7 +9,7 @@ module "acs" {
 
 module "lambda_api" {
   #  source = "../../"
-  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.0.0"
+  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.0.1"
   app_name                      = "my-lambda-dev"
   zip_filename                  = "./src/lambda.zip"
   zip_handler                   = "index.handler"

--- a/examples/simple-lambda-in-vpc/example.tf
+++ b/examples/simple-lambda-in-vpc/example.tf
@@ -9,7 +9,7 @@ module "acs" {
 
 module "lambda_api" {
   # source                        = "../../"
-  source       = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.0.0"
+  source       = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.0.1"
   app_name     = "my-lambda-dev"
   zip_filename = "./src/lambda.zip"
   zip_handler  = "index.handler"

--- a/examples/simple-lambda-with-deploy-test/example.tf
+++ b/examples/simple-lambda-with-deploy-test/example.tf
@@ -9,7 +9,7 @@ module "acs" {
 
 module "lambda_api" {
   #  source = "../../"
-  source       = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.0.0"
+  source       = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.0.1"
   app_name     = "my-lambda-codedeploy-dev"
   env          = "dev"
   zip_filename = "./src/lambda.zip"

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,9 @@
 variable "app_name" {
   type        = string
-  description = "Application name to name your Fargate API and other resources. Must be <= 24 characters."
+  description = "Application name to name your Fargate API and other resources. Must be <= 28 characters."
   validation {
-    condition     = length(var.app_name) <= 24
-    error_message = "Must be <= 24 characters."
+    condition     = length(var.app_name) <= 28
+    error_message = "Must be <= 28 characters."
   }
 }
 


### PR DESCRIPTION
This lambda-api module only adds 4 characters (`-dev`) to `app_name` for the alb name (which can have a max of 32 characters). so setting the max to 28 instead of 24

And added dependabot, and changed default branch to `main`