### PR TITLE
Set `desync_mitigation_mode` to `strictest` in ALB

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Also Note: CodePipeline and CodeDeploy cannot be used together to deploy a Lambd
 For a Zip file lambda
 ```hcl
 module "lambda_api" {
-  source       = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.2.0"
+  source       = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.2.1"
   app_name     = "my-lambda-codedeploy-dev"
   zip_filename = "./src/lambda.zip"
   zip_handler  = "index.handler"
@@ -50,7 +50,7 @@ module "lambda_api" {
 For a docker image lambda:
 ```hcl
 module "lambda_api" {
-  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.2.0"
+  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.2.1"
   app_name                      = "my-docker-lambda"
   image_uri                     = "my-image-from-my-ecr:latest"
   hosted_zone                   = module.acs.route53_zone

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Also Note: CodePipeline and CodeDeploy cannot be used together to deploy a Lambd
 For a Zip file lambda
 ```hcl
 module "lambda_api" {
-  source       = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.2.1"
+  source       = "github.com/byu-oit/terraform-aws-lambda-api?ref=v3.0.0"
   app_name     = "my-lambda-codedeploy-dev"
   zip_filename = "./src/lambda.zip"
   zip_handler  = "index.handler"
@@ -50,7 +50,7 @@ module "lambda_api" {
 For a docker image lambda:
 ```hcl
 module "lambda_api" {
-  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.2.1"
+  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v3.0.0"
   app_name                      = "my-docker-lambda"
   image_uri                     = "my-image-from-my-ecr:latest"
   hosted_zone                   = module.acs.route53_zone
@@ -86,7 +86,7 @@ module "lambda_api" {
 
 ## Requirements
 * Terraform version 0.13.2 or greater
-* AWS provider version 3.0 or greater
+* AWS provider version 3.67 or greater
 
 ## Inputs
 | Name                          | Type                                  | Description                                                                                                                                                                                                                                         | Default                                                                                |

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## v2.2.1
+## v3.0.0
 2/6/2023 - Set `desync_mitigation_mode` to `strictest` in ALB
+- Require AWS provider >=3.67 to support `desync_mitigation_mode`
 
 ## v2.2.0
 11/18/2022 - support ARM 64 architecture

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v2.2.1
+2/6/2023 - Set `desync_mitigation_mode` to `strictest` in ALB
+
 ## v2.2.0
 11/18/2022 - support ARM 64 architecture
 - allow pass through of architecture to support arm64. Default is x86_64.

--- a/examples/ci-0_13/ci.tf
+++ b/examples/ci-0_13/ci.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 3.0"
+  version = "~> 3.67"
   region  = "us-west-2"
 }
 

--- a/examples/ci-0_14/ci.tf
+++ b/examples/ci-0_14/ci.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 3.0"
+  version = "~> 3.67"
   region  = "us-west-2"
 }
 

--- a/examples/ci-1/ci.tf
+++ b/examples/ci-1/ci.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.73.0"
+      version = "~> 3.67"
     }
   }
 }

--- a/examples/docker-lambda/docker.tf
+++ b/examples/docker-lambda/docker.tf
@@ -9,7 +9,7 @@ module "acs" {
 
 module "lambda_api" {
   #  source                        = "../../"
-  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.2.0"
+  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.2.1"
   app_name                      = "my-docker-lambda"
   image_uri                     = "my-image-from-my-ecr:latest"
   hosted_zone                   = module.acs.route53_zone

--- a/examples/docker-lambda/docker.tf
+++ b/examples/docker-lambda/docker.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 3.0"
+  version = "~> 3.67"
   region  = "us-west-2"
 }
 
@@ -9,7 +9,7 @@ module "acs" {
 
 module "lambda_api" {
   #  source                        = "../../"
-  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.2.1"
+  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v3.0.0"
   app_name                      = "my-docker-lambda"
   image_uri                     = "my-image-from-my-ecr:latest"
   hosted_zone                   = module.acs.route53_zone

--- a/examples/no-codedeploy/example.tf
+++ b/examples/no-codedeploy/example.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 3.0"
+  version = "~> 3.67"
   region  = "us-west-2"
 }
 

--- a/examples/simple-lambda-in-vpc/example.tf
+++ b/examples/simple-lambda-in-vpc/example.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 3.0"
+  version = "~> 3.67"
   region  = "us-west-2"
 }
 
@@ -9,7 +9,7 @@ module "acs" {
 
 module "lambda_api" {
   # source                        = "../../"
-  source       = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.2.1"
+  source       = "github.com/byu-oit/terraform-aws-lambda-api?ref=v3.0.0"
   app_name     = "my-lambda-dev"
   zip_filename = "./src/lambda.zip"
   zip_handler  = "index.handler"

--- a/examples/simple-lambda-in-vpc/example.tf
+++ b/examples/simple-lambda-in-vpc/example.tf
@@ -9,7 +9,7 @@ module "acs" {
 
 module "lambda_api" {
   # source                        = "../../"
-  source       = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.2.0"
+  source       = "github.com/byu-oit/terraform-aws-lambda-api?ref=v2.2.1"
   app_name     = "my-lambda-dev"
   zip_filename = "./src/lambda.zip"
   zip_handler  = "index.handler"

--- a/examples/simple-lambda-with-deploy-test/example.tf
+++ b/examples/simple-lambda-with-deploy-test/example.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 3.0"
+  version = "~> 3.67"
   region  = "us-west-2"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -29,10 +29,11 @@ locals {
 # ==================== ALB ====================
 
 resource "aws_alb" "alb" {
-  name            = local.alb_name
-  subnets         = var.public_subnet_ids
-  security_groups = [aws_security_group.alb-sg.id]
-  tags            = var.tags
+  name                   = local.alb_name
+  desync_mitigation_mode = "strictest"
+  subnets                = var.public_subnet_ids
+  security_groups        = [aws_security_group.alb-sg.id]
+  tags                   = var.tags
 }
 
 resource "aws_security_group" "alb-sg" {

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = ">= 0.13.2"
   required_providers {
-    aws = ">= 3.0"
+    aws = ">= 3.67"
   }
 }
 


### PR DESCRIPTION
[`desync_mitigation_mode`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb#desync_mitigation_mode) was added in [AWS provider v3.67.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v3.67.0). This is a breaking change, because we [currently require v3.0.0](https://github.com/byu-oit/terraform-aws-lambda-api/blob/50acfa7997504743c6a153e83b669419dbc81fd3/main.tf#L4).