### PR TITLE
Back off desync_mitigation_mode to defensive

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Also Note: CodePipeline and CodeDeploy cannot be used together to deploy a Lambd
 For a Zip file lambda
 ```hcl
 module "lambda_api" {
-  source       = "github.com/byu-oit/terraform-aws-lambda-api?ref=v3.0.0"
+  source       = "github.com/byu-oit/terraform-aws-lambda-api?ref=v3.0.1"
   app_name     = "my-lambda-codedeploy-dev"
   zip_filename = "./src/lambda.zip"
   zip_handler  = "index.handler"
@@ -50,7 +50,7 @@ module "lambda_api" {
 For a docker image lambda:
 ```hcl
 module "lambda_api" {
-  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v3.0.0"
+  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v3.0.1"
   app_name                      = "my-docker-lambda"
   image_uri                     = "my-image-from-my-ecr:latest"
   hosted_zone                   = module.acs.route53_zone

--- a/examples/docker-lambda/docker.tf
+++ b/examples/docker-lambda/docker.tf
@@ -9,7 +9,7 @@ module "acs" {
 
 module "lambda_api" {
   #  source                        = "../../"
-  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v3.0.0"
+  source                        = "github.com/byu-oit/terraform-aws-lambda-api?ref=v3.0.1"
   app_name                      = "my-docker-lambda"
   image_uri                     = "my-image-from-my-ecr:latest"
   hosted_zone                   = module.acs.route53_zone

--- a/examples/simple-lambda-in-vpc/example.tf
+++ b/examples/simple-lambda-in-vpc/example.tf
@@ -9,7 +9,7 @@ module "acs" {
 
 module "lambda_api" {
   # source                        = "../../"
-  source       = "github.com/byu-oit/terraform-aws-lambda-api?ref=v3.0.0"
+  source       = "github.com/byu-oit/terraform-aws-lambda-api?ref=v3.0.1"
   app_name     = "my-lambda-dev"
   zip_filename = "./src/lambda.zip"
   zip_handler  = "index.handler"

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ locals {
 
 resource "aws_alb" "alb" {
   name                   = local.alb_name
-  desync_mitigation_mode = "strictest"
+  desync_mitigation_mode = "defensive"
   subnets                = var.public_subnet_ids
   security_groups        = [aws_security_group.alb-sg.id]
   tags                   = var.tags


### PR DESCRIPTION
Setting desync_mitigation_mode to strictest breaks clients that
aren't strictly RFC 7230 compliant (notably, AWS API Gateway).
Setting this attribute to defensive provides sufficent protection
against desync attacks, while still allowing requests from clients
that we can't perfect.
https://en.wikipedia.org/wiki/Robustness_principle
