### PR TITLE
refactor: require AWS provider 5.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ module "lambda_api" {
 
 ## Requirements
 * Terraform version 0.13.2 or greater
-* AWS provider version 3.67 or greater
+* AWS provider version 5.26 or greater
 
 ## Inputs
 | Name                          | Type                                  | Description                                                                                                                                                                                                                                         | Default                                                                                |

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.0.0
+2/6/2023 - Enable support for nodejs20.x runtime
+- Require AWS provider >=5.26 to support nodejs20.x runtime
+
 ## v3.0.0
 2/6/2023 - Set `desync_mitigation_mode` to `strictest` in ALB
 - Require AWS provider >=3.67 to support `desync_mitigation_mode`

--- a/examples/docker-lambda/docker.tf
+++ b/examples/docker-lambda/docker.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 3.67"
+  version = "~> 5.26"
   region  = "us-west-2"
 }
 

--- a/examples/simple-lambda-in-vpc/example.tf
+++ b/examples/simple-lambda-in-vpc/example.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 3.67"
+  version = "~> 5.26"
   region  = "us-west-2"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = ">= 0.13.2"
   required_providers {
-    aws = ">= 3.67"
+    aws = ">= 5.26"
   }
 }
 


### PR DESCRIPTION
This is to allow nodejs20.x (see https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5260-november-16-2023)

After this I will make a release to 4.0.0